### PR TITLE
Force lowercase on emails collected from client

### DIFF
--- a/access_guard/forms.py
+++ b/access_guard/forms.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from pydantic.networks import EmailStr
 
 from .validators import DisallowedEmail, check_email_is_allowed
@@ -6,6 +6,9 @@ from .validators import DisallowedEmail, check_email_is_allowed
 
 class SendEmailForm(BaseModel):
     email: EmailStr
+
+    # It's a bit sad that pydantic doesn't accept `str.lower` directly as validator..
+    _normalize_email = validator("email", always=True)(lambda value: value.lower())
 
     @property
     def has_allowed_email(self) -> bool:


### PR DESCRIPTION
- Allows case insensitive matching against configured patterns