### PR TITLE
Make configured email patterns case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Optional cookie arguments:
 
   Email address patterns to match for being allowed possibility to verify and access.
 
+  All entered patterns are case insensitively matched with emails entered by a client.
+
   Example:
 
   ```

--- a/access_guard/cli.py
+++ b/access_guard/cli.py
@@ -21,6 +21,10 @@ def command(argv: list[str] | None = None) -> None:
     start_server()
 
 
+def compiled_lowercase_regex(pattern: str) -> re.Pattern:
+    return re.compile(f"{pattern.lower()}")
+
+
 def parse_argv(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="access-guard", description="...")
     required = parser.add_argument_group(title="Required arguments")
@@ -39,8 +43,7 @@ def parse_argv(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "email_patterns",
         metavar="EMAIL_PATTERN",
-        # type is expecting a str, while re.compile expects a r"..."
-        type=re.compile,  # type: ignore[arg-type]
+        type=compiled_lowercase_regex,
         nargs="+",
         help="Email addresses to match, each compiled to a regex",
     )

--- a/access_guard/cli.py
+++ b/access_guard/cli.py
@@ -21,7 +21,7 @@ def command(argv: list[str] | None = None) -> None:
     start_server()
 
 
-def compiled_lowercase_regex(pattern: str) -> re.Pattern:
+def lowercase_regex_pattern(pattern: str) -> re.Pattern:
     return re.compile(f"{pattern.lower()}")
 
 
@@ -43,7 +43,7 @@ def parse_argv(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "email_patterns",
         metavar="EMAIL_PATTERN",
-        type=compiled_lowercase_regex,
+        type=lowercase_regex_pattern,
         nargs="+",
         help="Email addresses to match, each compiled to a regex",
     )


### PR DESCRIPTION
- Since posted emails are forced lowercase, cli is matching that