### PR TITLE
Set up CSRF prevention for /send endpoint

### DIFF
--- a/access_guard/csrf.py
+++ b/access_guard/csrf.py
@@ -1,0 +1,37 @@
+import secrets
+import string
+
+from itsdangerous.exc import BadData
+
+from . import settings
+
+CSRF_ALLOWED_CHARS = string.ascii_letters + string.digits
+CSRF_TOKEN_LENGTH = 32
+CSRF_COOKIE_NAME = "_csrftoken"
+CSRF_COOKIE_MAX_AGE = 3600  # 1 hour
+
+
+def get_token() -> tuple[str, str]:
+    value = "".join(
+        secrets.choice(CSRF_ALLOWED_CHARS) for __ in range(CSRF_TOKEN_LENGTH)
+    )
+    __, signature = (
+        dumped
+        if isinstance((dumped := settings.SIGNING.url_safe.dumps(value)), str)
+        else dumped.decode()
+    ).rsplit(settings.SIGNING.separator, 1)
+    return value, signature
+
+
+def does_token_match(body_csrf: str, cookie_csrf: str) -> bool:
+    serializer = settings.SIGNING.url_safe
+    try:
+        csrf_token = serializer.loads(
+            settings.SIGNING.separator.join(
+                [serializer.dump_payload(body_csrf).decode(), cookie_csrf]
+            )
+        )
+    except (ValueError, TypeError, BadData):
+        return False
+
+    return secrets.compare_digest(body_csrf, csrf_token)

--- a/access_guard/forms.py
+++ b/access_guard/forms.py
@@ -6,6 +6,7 @@ from .validators import DisallowedEmail, check_email_is_allowed
 
 class SendEmailForm(BaseModel):
     email: EmailStr
+    csrf_token: str
 
     # It's a bit sad that pydantic doesn't accept `str.lower` directly as validator..
     _normalize_email = validator("email", always=True)(lambda value: value.lower())

--- a/access_guard/settings.py
+++ b/access_guard/settings.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Any, NamedTuple, Sequence
 
-from itsdangerous.url_safe import URLSafeTimedSerializer
+from itsdangerous.url_safe import URLSafeSerializer, URLSafeTimedSerializer
 from starlette.config import Config
 from starlette.datastructures import Secret
 
@@ -51,6 +51,7 @@ DEBUG: bool = config("debug", cast=bool, default=False)
 
 class Signers(NamedTuple):
     timed: URLSafeTimedSerializer
+    url_safe: URLSafeSerializer
     separator: str
 
 
@@ -58,6 +59,11 @@ SIGNING = Signers(
     timed=URLSafeTimedSerializer(
         str(SECRET),
         salt="access_guard.signing.timed",
+        signer_kwargs={"sep": ".", "digest_method": hashlib.sha256},
+    ),
+    url_safe=URLSafeSerializer(
+        str(SECRET),
+        salt="access_guard.signing.url_safe",
         signer_kwargs={"sep": ".", "digest_method": hashlib.sha256},
     ),
     separator=".",

--- a/access_guard/templates/send_email.html
+++ b/access_guard/templates/send_email.html
@@ -13,6 +13,7 @@
     <div class="Container">
       <div class="AuthBox">
         <form action="{{ url_for('send') }}" method="post" autocomplete="off">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
           <div class="AuthBox-content">
             <div class="AuthBox-row">
               <h4 class="AuthBox-title">Verify via email</h4>

--- a/access_guard/tests/test_csrf.py
+++ b/access_guard/tests/test_csrf.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from .. import csrf
+
+
+class TestDoesTokenMatch:
+    @pytest.mark.parametrize(
+        "value",
+        (
+            pytest.param(datetime(2021, 1, 1), id="type error"),
+            pytest.param("abcdef", id="bad data"),
+        ),
+    )
+    def test_returns_false_when_loading_signature_raises(self, value: Any) -> None:
+        assert csrf.does_token_match(value, "other value") is False

--- a/access_guard/tests/test_forms.py
+++ b/access_guard/tests/test_forms.py
@@ -7,7 +7,9 @@ from ..forms import SendEmailForm
 class TestSendEmailForms:
     def test_raises_validation_error_with_invalid_email(self) -> None:
         with pytest.raises(ValidationError) as exc:
-            SendEmailForm.parse_obj({"email": "!@dlkfjs@email.com"})
+            SendEmailForm.parse_obj(
+                {"email": "!@dlkfjs@email.com", "csrf_token": "something"}
+            )
 
         assert exc.value.errors() == [
             {


### PR DESCRIPTION
- With (stateless) double submit cookie approach