### PR TITLE
Setup multiple log formatters (json, console)

### DIFF
--- a/access_guard/cli.py
+++ b/access_guard/cli.py
@@ -143,6 +143,14 @@ def parse_argv(argv: list[str]) -> argparse.Namespace:
         default=8585,
         help="Server port. [default: 8585]",
     )
+    parser.add_argument(
+        "--log-formatter",
+        type=str,
+        choices=("json", "console"),
+        default=argparse.SUPPRESS,
+        dest="log_formatter",
+        help="Log output format [default: json]",
+    )
     # Required email arguments
     email_required.add_argument(
         "--email-host",

--- a/access_guard/log.py
+++ b/access_guard/log.py
@@ -1,11 +1,14 @@
 import structlog
 from structlog.types import Processor
 
+from .settings import LOG_FORMATTER
+
 processors: tuple[Processor, ...] = (
-    structlog.threadlocal.merge_threadlocal,
+    structlog.contextvars.merge_contextvars,
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
     structlog.processors.TimeStamper(fmt="iso"),
+    structlog.processors.format_exc_info,
 )
 structlog.configure(
     processors=[
@@ -30,15 +33,20 @@ LOGGING_CONFIG: dict = {
             "processor": structlog.processors.JSONRenderer(),
             "foreign_pre_chain": processors,
         },
+        "console": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(),
+            "foreign_pre_chain": processors,
+        },
     },
     "handlers": {
         "default": {
-            "formatter": "json",
+            "formatter": LOG_FORMATTER,
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stderr",
         },
         "access": {
-            "formatter": "json",
+            "formatter": LOG_FORMATTER,
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stdout",
         },

--- a/access_guard/settings.py
+++ b/access_guard/settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+from enum import Enum
 from pathlib import Path
 from typing import Any, NamedTuple, Sequence
 
@@ -85,4 +86,14 @@ AUTH_SIGNATURE_MAX_AGE: int = config(
 # Default: 24 hours
 VERIFY_SIGNATURE_MAX_AGE: int = config(
     "verify_signature_max_age", cast=int, default=60 * 60 * 24
+)
+
+
+class LogFormatter(str, Enum):
+    JSON = "json"
+    CONSOLE = "console"
+
+
+LOG_FORMATTER: LogFormatter = config(
+    "log_formatter", cast=LogFormatter, default=LogFormatter.JSON
 )

--- a/access_guard/tests/conftest.py
+++ b/access_guard/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging.config
 from typing import AsyncGenerator, Generator
 from unittest import mock
 
@@ -25,12 +26,20 @@ environ.load(  # noqa
         "email_port": "666",
         "from_email": "access-guard@example.com",
         "email_subject": "Test verification",
+        "log_formatter": "console",
     }
 )
 
 from .. import settings  # noqa: E402
+from ..log import LOGGING_CONFIG  # noqa: E402
 from ..schema import AuthSignature  # noqa: E402
 from .factories import ForwardHeadersFactory  # noqa: E402
+
+
+# Configure logging for a bit nicer log ouputs during tests
+@pytest.fixture(scope="session", autouse=True)
+def _configure_logging() -> None:
+    logging.config.dictConfig(LOGGING_CONFIG)
 
 
 @pytest.fixture()

--- a/access_guard/tests/conftest.py
+++ b/access_guard/tests/conftest.py
@@ -36,7 +36,7 @@ from ..schema import AuthSignature  # noqa: E402
 from .factories import ForwardHeadersFactory  # noqa: E402
 
 
-# Configure logging for a bit nicer log ouputs during tests
+# Configure logging for a bit nicer log outputs during tests
 @pytest.fixture(scope="session", autouse=True)
 def _configure_logging() -> None:
     logging.config.dictConfig(LOGGING_CONFIG)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,8 @@ services:
       "--cookie-domain", "localhost.com",
       "--email-host", "mailhog",
       "--email-port", "1025",
-      "--from-email", "access-guard@local.com"
+      "--from-email", "access-guard@local.com",
+      "--log-formatter", "console",
       ]
     stdin_open: true
     tty: true

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -12,9 +12,23 @@ emails to.
 
 ```console
 $ docker run --rm ghcr.io/flaeppe/access-guard:latest --help
-usage: access-guard [-h] -s SECRET -a AUTH_HOST -t TRUSTED_HOST [TRUSTED_HOST ...] -c COOKIE_DOMAIN [-V] [-d] [--host HOST] [--port PORT] --email-host EMAIL_HOST --email-port EMAIL_PORT --from-email FROM_EMAIL [--email-username EMAIL_USERNAME]
-                    [--email-password EMAIL_PASSWORD] [--email-use-tls | --email-start-tls] [--email-validate-certs] [--email-client-cert EMAIL_CLIENT_CERT] [--email-client-key EMAIL_CLIENT_KEY] [--email-subject EMAIL_SUBJECT] [--cookie-secure]
-                    [--auth-cookie-name AUTH_COOKIE_NAME] [--verified-cookie-name VERIFIED_COOKIE_NAME] [--auth-cookie-max-age AUTH_COOKIE_MAX_AGE] [--auth-signature-max-age AUTH_SIGNATURE_MAX_AGE] [--verify-signature-max-age VERIFY_SIGNATURE_MAX_AGE]
+usage: access-guard [-h] (-s SECRET | -sf PATH_TO_FILE) -a AUTH_HOST -t
+                    TRUSTED_HOST [TRUSTED_HOST ...] -c COOKIE_DOMAIN [-V] [-d]
+                    [--host HOST] [--port PORT]
+                    [--log-formatter {json,console}] --email-host EMAIL_HOST
+                    --email-port EMAIL_PORT --from-email FROM_EMAIL
+                    [--email-username EMAIL_USERNAME]
+                    [--email-password EMAIL_PASSWORD | --email-password-file PATH_TO_FILE]
+                    [--email-use-tls | --email-start-tls]
+                    [--email-no-validate-certs]
+                    [--email-client-cert EMAIL_CLIENT_CERT]
+                    [--email-client-key EMAIL_CLIENT_KEY]
+                    [--email-subject EMAIL_SUBJECT] [--cookie-secure]
+                    [--auth-cookie-name AUTH_COOKIE_NAME]
+                    [--verified-cookie-name VERIFIED_COOKIE_NAME]
+                    [--auth-cookie-max-age AUTH_COOKIE_MAX_AGE]
+                    [--auth-signature-max-age AUTH_SIGNATURE_MAX_AGE]
+                    [--verify-signature-max-age VERIFY_SIGNATURE_MAX_AGE]
                     EMAIL_PATTERN [EMAIL_PATTERN ...]
 
 ...
@@ -22,12 +36,14 @@ usage: access-guard [-h] -s SECRET -a AUTH_HOST -t TRUSTED_HOST [TRUSTED_HOST ..
 positional arguments:
   EMAIL_PATTERN         Email addresses to match, each compiled to a regex
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
   -d, --debug
   --host HOST           Server host. [default: 0.0.0.0]
   --port PORT           Server port. [default: 8585]
+  --log-formatter {json,console}
+                        Log output format [default: json]
 
 Required arguments:
   -s SECRET, --secret SECRET
@@ -35,11 +51,16 @@ Required arguments:
   -sf PATH_TO_FILE, --secret-file PATH_TO_FILE
                         Secret key file
   -a AUTH_HOST, --auth-host AUTH_HOST
-                        The entrypoint url for access guard, with protocol and path
+                        The entrypoint url for access guard, with protocol and
+                        path
   -t TRUSTED_HOST [TRUSTED_HOST ...], --trusted-hosts TRUSTED_HOST [TRUSTED_HOST ...]
-                        Hosts/domain names that access guard should serve. Matched against a request's Host header. Wildcard domains such as '*.example.com' are supported for matching subdomains. To allow any hostname use: *
+                        Hosts/domain names that access guard should serve.
+                        Matched against a request's Host header. Wildcard
+                        domains such as '*.example.com' are supported for
+                        matching subdomains. To allow any hostname use: *
   -c COOKIE_DOMAIN, --cookie-domain COOKIE_DOMAIN
-                        The domain to use for cookies. Ensure this value covers domain set for AUTH_HOST
+                        The domain to use for cookies. Ensure this value
+                        covers domain set for AUTH_HOST
 
 Required email arguments:
   SMTP/Email specific configuration
@@ -47,7 +68,8 @@ Required email arguments:
   --email-host EMAIL_HOST
                         The host to use for sending emails
   --email-port EMAIL_PORT
-                        Port to use for the SMTP server defined in --email-host
+                        Port to use for the SMTP server defined in --email-
+                        host
   --from-email FROM_EMAIL
                         What will become the sender's address in sent emails
 
@@ -55,36 +77,56 @@ Optional email arguments:
   SMTP/Email specific configuration
 
   --email-username EMAIL_USERNAME
-                        Username to login with on configured SMTP server [default: unset]
+                        Username to login with on configured SMTP server
+                        [default: unset]
   --email-password EMAIL_PASSWORD
-                        Password to login with on configured SMTP server [default: unset]
+                        Password to login with on configured SMTP server
+                        [default: unset]
   --email-password-file PATH_TO_FILE
-                        File containing password to login with on configured SMTP server [default: unset]
-  --email-use-tls       Make the _initial_ connection to the SMTP server over TLS/SSL [default: false]
-  --email-start-tls     Make the initial connection to the SMTP server over plaintext, and then upgrade the connection to TLS/SSL [default: false]
+                        File containing password to login with on configured
+                        SMTP server [default: unset]
+  --email-use-tls       Make the _initial_ connection to the SMTP server over
+                        TLS/SSL [default: false]
+  --email-start-tls     Make the initial connection to the SMTP server over
+                        plaintext, and then upgrade the connection to TLS/SSL
+                        [default: false]
   --email-no-validate-certs
-                        Disable validating server certificates for SMTP [default: false]
+                        Disable validating server certificates for SMTP
+                        [default: false]
   --email-client-cert EMAIL_CLIENT_CERT
-                        Path to client side certificate, for TLS verification [default: unset]
+                        Path to client side certificate, for TLS verification
+                        [default: unset]
   --email-client-key EMAIL_CLIENT_KEY
-                        Path to client side key, for TLS verification [default: unset]
+                        Path to client side key, for TLS verification
+                        [default: unset]
   --email-subject EMAIL_SUBJECT
-                        Subject of the email sent for verification [default: Access guard verification]
+                        Subject of the email sent for verification [default:
+                        Access guard verification]
 
 Optional cookie arguments:
   Configuration for cookies
 
-  --cookie-secure       Whether to only use secure cookies. When passed, cookies will be marked as 'secure' [default: false]
+  --cookie-secure       Whether to only use secure cookies. When passed,
+                        cookies will be marked as 'secure' [default: false]
   --auth-cookie-name AUTH_COOKIE_NAME
-                        Name for cookie used during auth flow [default: access-guard-forwarded]
+                        Name for cookie used during auth flow [default:
+                        access-guard-forwarded]
   --verified-cookie-name VERIFIED_COOKIE_NAME
-                        Name for cookie set when auth completed successfully [default: access-guard-session]
+                        Name for cookie set when auth completed successfully
+                        [default: access-guard-session]
   --auth-cookie-max-age AUTH_COOKIE_MAX_AGE
-                        Seconds before the cookie set _during_ auth flow should expire [default: 3600 (1 hour)]
+                        Seconds before the cookie set _during_ auth flow
+                        should expire [default: 3600 (1 hour)]
   --auth-signature-max-age AUTH_SIGNATURE_MAX_AGE
-                        Decides how many seconds a verification email should be valid. When the amount of seconds has passed, the client has to request a new email. [default: 600 (10 minutes)]
+                        Decides how many seconds a verification email should
+                        be valid. When the amount of seconds has passed, the
+                        client has to request a new email. [default: 600 (10
+                        minutes)]
   --verify-signature-max-age VERIFY_SIGNATURE_MAX_AGE
-                        Decides how many seconds a verified session cookie should be valid. When the amount of seconds has passed, the client has to verify again. [default: 86400 (24 hours)]
+                        Decides how many seconds a verified session cookie
+                        should be valid. When the amount of seconds has
+                        passed, the client has to verify again. [default:
+                        86400 (24 hours)]
 ```
 
 ## Arguments reference
@@ -285,6 +327,16 @@ docker run --rm ghcr.io/flaeppe/access-guard:latest \
     ???+ info "Default value"
 
         8585
+
+#### Log formatter
+
+:   `--log-formatter`
+
+    Log output format, available choices are `json` or `console`
+
+    ???+ info "Default value"
+
+        json
 
 #### SMTP client username
 


### PR DESCRIPTION
- Default log formatter to json
- Enable console log formatter for tests
- Enable console log formatter in docker-compose